### PR TITLE
Fix technology hover cursor

### DIFF
--- a/compatibility/src/index.svelte
+++ b/compatibility/src/index.svelte
@@ -27,7 +27,6 @@
 
   .technology:hover img {
     transform: scale(1.1);
-    cursor: pointer;
   }
 
   .technology figcaption {


### PR DESCRIPTION
How it is now on https://backlight.dev/private/:

https://user-images.githubusercontent.com/137844/122021101-a676ff80-cdc5-11eb-974b-0548744867d4.mov

Pointer is not needed on a non-clickable element, it confuses, my first reaction was that links were broken.